### PR TITLE
Fix cappy from disappearing after throw -> spin

### DIFF
--- a/user/src/main.cpp
+++ b/user/src/main.cpp
@@ -140,7 +140,6 @@ public:
         PlayerStateSpinCap* state = keeper->getParent<PlayerStateSpinCap>();
 
         if(al::isFirstStep(state)) {
-            state->mAnimator->endSubAnim();
             state->mAnimator->startAnim("SpinSeparate");
             al::validateHitSensor(state->mActor, "GalaxySpin");
         }


### PR DESCRIPTION
In the case described here, Cappy is set to invisible and returned to visible in the animation. If that animation is canceled, Cappy stays invisible. So ... don't cancel it. This code was inserted to allow GalaxySpins to interrupt fake-capthrows, but as fake-capthrows were entirely removed in this mod, canceling the current animation is not required at all.